### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This plugin allows vim to use [Racer](http://github.com/phildawes/racer) for Rus
 
   NeoBundle users:
   ```
-  NeoBundle 'racer-rust/vim-racer', {
-  \   'build' : {
-  \     'mac': 'cargo build --release',
-  \     'unix': 'cargo build --release',
-  \   }
-  \ }
+  NeoBundle 'racer-rust/vim-racer'
+  ```
+  
+  vim-plug users:
+  ```
+  Plug 'racer-rust/vim-racer'
   ```
 
 2. Add g:racer_cmd and $RUST_SRC_PATH variables to your .vimrc. Also it's worth turning on 'hidden' mode for buffers otherwise you need to save the current buffer every time you do a goto-definition. E.g.:


### PR DESCRIPTION
Since the vim plugin is now sperate from the core racer, it is no longer nessessary to build racer after updating the plugin.
Also I've added the configuration for vim-plug.
