### PR TITLE
show overloads in completions

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -94,7 +94,7 @@ candidates = []
 for line in lines:
     completions = line.split(',',5)
     kind = typeMap[completions[4]]
-    completion = {'kind' : kind, 'word' : completions[0]}
+    completion = {'kind' : kind, 'word' : completions[0], 'dup':1 }
     if kind == 'f': #function
         completion['abbr'] = completions[5].replace('pub ','').replace('fn ','').rstrip('{')
         if int(vim.eval('g:racer_insert_paren')):


### PR DESCRIPTION
add dup option to complete-item.
it can show overloads like `as_ref(&self)->&Vec<T>`, `as_ref(&self)->&[T]` both. Previous only show `as_ref(&self)->&Vec<T>`.
