### PR TITLE
Define buffer-local mappings

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -186,8 +186,8 @@ function! RacerComplete(findstart, base)
 endfunction
 
 autocmd FileType rust setlocal omnifunc=RacerComplete
-autocmd FileType rust nnoremap gd :call RacerGoToDefinition()<cr>
-autocmd FileType rust nnoremap gD :vsplit<cr>:call RacerGoToDefinition()<cr>
+autocmd FileType rust nnoremap <buffer>gd :call RacerGoToDefinition()<cr>
+autocmd FileType rust nnoremap <buffer>gD :vsplit<cr>:call RacerGoToDefinition()<cr>
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Currently vim-racer defines **global** mappings.  I avoided it with `<buffer>`, which defines buffer local mapping.
