### PR TITLE
force update complete menu

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -72,7 +72,8 @@ function! RacerGetPrefixCol(base)
 endfunction
 
 function! RacerGetExpCompletions(base)
-    let col = b:racer_col      " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
+    let col = strlen(getline('.')) + strlen(a:base)     " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
+    call writefile(RacerGetBufferContents(a:base), b:tmpfname)
     let fname = expand("%:p")
     let cmd = g:racer_cmd." complete ".line(".")." ".col." ".fname." ".b:tmpfname
     let res = system(cmd)
@@ -112,7 +113,8 @@ function! RacerGetExpCompletions(base)
 endfunction
 
 function! RacerGetCompletions(base)
-    let col = b:racer_col      " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
+    let col = strlen(getline('.')) + strlen(a:base)     " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
+    call writefile(RacerGetBufferContents(a:base), b:tmpfname)
     let fname = expand("%:p")
     let cmd = g:racer_cmd." complete ".line(".")." ".col." ".fname." ".b:tmpfname
     let res = system(cmd)


### PR DESCRIPTION
I have `ycm` installed, so my complete menu will pop after `.`, `::`. 
The complete menu did not update while I enter the prefix chars of the item in completion list unless `<c-x><c-o>` active ( or `<c-space>` from `ycm`'s config). ( due to `getline('.')` did not return the updated context and param `base` in`RacerComplete` is still empty with `findstart = 1`)
