### PR TITLE
Fixed problem when path to current file has spaces

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -75,7 +75,7 @@ function! RacerGetExpCompletions(base)
     let col = strlen(getline('.')) + strlen(a:base)     " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
     call writefile(RacerGetBufferContents(a:base), b:tmpfname)
     let fname = expand("%:p")
-    let cmd = g:racer_cmd." complete ".line(".")." ".col." ".fname." ".b:tmpfname
+    let cmd = g:racer_cmd." complete ".line(".")." ".col." \"".fname."\" \"".b:tmpfname."\""
     let res = system(cmd)
 
     let typeMap = {
@@ -116,7 +116,7 @@ function! RacerGetCompletions(base)
     let col = strlen(getline('.')) + strlen(a:base)     " use the column from the previous RacerGetPrefixCol() call, since vim ammends it afterwards
     call writefile(RacerGetBufferContents(a:base), b:tmpfname)
     let fname = expand("%:p")
-    let cmd = g:racer_cmd." complete ".line(".")." ".col." ".fname." ".b:tmpfname
+    let cmd = g:racer_cmd." complete ".line(".")." ".col." \"".fname."\" \"".b:tmpfname."\""
     let res = system(cmd)
     let lines = split(res, "\\n")
     let out = []


### PR DESCRIPTION
Just needed quotes around paths passed to racer, tested on Windows 10 and Ubuntu.
