### PR TITLE
Swap files given to racer.

### DIFF
--- a/rplugin/python3/deoplete/sources/racer.py
+++ b/rplugin/python3/deoplete/sources/racer.py
@@ -102,8 +102,8 @@ class Source(Base):
                 self.__racer, command,
                 str(self.vim.funcs.line('.')),
                 str(col - 1),
-                tf.name,
-                self.vim.current.buffer.name
+                self.vim.current.buffer.name,
+                tf.name
             ]
             try:
                 results = subprocess.check_output(args).decode(


### PR DESCRIPTION
Current version of racer (racer 1.2.6, 8a0d10a) counts characters in substitute file. When giving current buffer as current file we get wrong line matched or go out of bounds.
