### PR TITLE
Add support for documentation

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -101,6 +101,66 @@ function! s:RacerGetExpCompletions(base)
     return out
 endfunction
 
+function! s:RacerSplitLine(line)
+    let b:parts = []
+    let separator = ';'
+    let placeholder = '{PLACEHOLDER}'
+    let line = substitute(a:line, '\\;', placeholder, 'g')
+    let b:parts = split(line, separator)
+    let docs = substitute(substitute(substitute(substitute(b:parts[7], '^\"\(.*\)\"$', '\1', ''), '\\\"', '\"', 'g'), '\\''', '''', 'g'), '\\n', '\n', 'g')
+    let b:parts[7] = docs
+    let b:parts = map(copy(b:parts), 'substitute(v:val, ''{PLACEHOLDER}'', '';'', ''g'')')
+
+    return b:parts
+endfunction
+
+function! s:RacerShowDocumentation()
+    let l:winview = winsaveview()  " Save the current cursor position
+    " Move to the end of the word for the entire token to search
+    execute "normal e"
+    let col = col('.')
+    let b:tmpfname = tempname()
+    call writefile(getline(1, '$'), b:tmpfname)  " Create temporary file with the buffer's current state
+    let fname = expand("%:p")
+    let cmd = g:racer_cmd." complete-with-snippet ".line(".")." ".col." ".fname." ".b:tmpfname
+    let res = system(cmd)
+    let lines = split(res, "\\n")
+    let out = []
+    for line in lines
+       if line =~ "^MATCH"
+           let completion = s:RacerSplitLine(line[6:])[7]
+           let docs = add(out, completion)
+           if len(docs) > 0  " Only open doc buffer if there're docs to show
+               let bn = bufnr("__doc__")
+               if bn > 0
+                   let wi=index(tabpagebuflist(tabpagenr()), bn)
+                   if wi >= 0
+                       " If the __doc__ buffer is open in the current tab, jump to it
+                       silent execute (wi+1).'wincmd w'
+                   else
+                       silent execute "sbuffer ".bn
+                   endif
+               else
+                   split '__doc__'
+               endif
+
+               setlocal modifiable
+               setlocal noswapfile
+               setlocal buftype=nofile
+               silent normal! ggdG
+               silent $put=docs
+               silent normal! 1Gdd
+               setlocal nomodifiable
+               setlocal nomodified
+               setlocal filetype=markdown
+           endif
+           break
+       endif
+    endfor
+    call winrestview(l:winview)  " Restore de cursor position
+    call delete(b:tmpfname)  " Delete the temporary file
+endfunction
+
 function! s:RacerGetCompletions(base)
     let col = col(".")-1
     call writefile(s:RacerGetBufferContents(a:base), b:tmpfname)
@@ -111,11 +171,13 @@ function! s:RacerGetCompletions(base)
     let out = []
     for line in lines
        if line =~ "^MATCH"
-           let completion = split(line[6:], ",")[0]
+           let spl = s:RacerSplitLine(line[6:])
+           let completion = spl[0]
            let out = add(out, completion)
        endif
     endfor
     call delete(b:tmpfname)
+
     return out
 endfunction
 
@@ -136,10 +198,11 @@ function! s:RacerGoToDefinition()
         if res =~# " error: " && line !=# "END"
             call s:Warn(line)
         elseif line =~ "^MATCH"
-             let linenum = split(line[6:], ",")[1]
-             let colnum = split(line[6:], ",")[2]
-             let fname = split(line[6:], ",")[3]
-             call s:RacerJumpToLocation(fname, linenum, colnum)
+             let spl = RacerSplitLine(line[6:])
+             let linenum = spl[1]
+             let colnum = spl[2]
+             let fname = spl[3]
+             call RacerJumpToLocation(fname, linenum, colnum)
              break
         endif
     endfor
@@ -150,7 +213,7 @@ function! s:RacerGetBufferContents(base)
     " Re-combine the completion base word from omnicomplete with the current
     " line contents. Since the base word gets remove from the buffer before
     " this function is invoked we have to put it back in to out tmpfile.
-    let col = col(".")-1
+    let col = col(".") - 1
     let buf_lines = getline(1, '$')
     let line_contents = getline('.')
     let buf_lines[line('.') - 1] = strpart(line_contents, 0, col).a:base.strpart(line_contents, col, len(line_contents))
@@ -215,7 +278,8 @@ autocmd FileType rust nnoremap <buffer><silent> gd
             \ :call <SID>RacerGoToDefinition()<cr>
 autocmd FileType rust nnoremap <buffer><silent> gD
             \ :vsplit<cr>:call <SID>RacerGoToDefinition()<cr>
+autocmd FileType rust nnoremap <buffer>K
+            \ :call <SID>RacerShowDocumentation()<cr>
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-

--- a/syntax/rustdoc.vim
+++ b/syntax/rustdoc.vim
@@ -1,0 +1,178 @@
+" Vim syntax file
+" Language:	Rust Documentation (Markdown)
+" Maintainer:	Esteban Kuber <esteban@kuber.com.ar>
+" Remark:	Uses HTML and Rust syntax files.
+" 				Based off plasticboy's Markdown Vim Mode:
+" 				  https://github.com/plasticboy/vim-markdown.
+" TODO: 	Handle stuff contained within stuff (e.g. headings within blockquotes)
+
+
+" Read the HTML syntax to start with
+if version < 600
+  so <sfile>:p:h/html.vim
+else
+  runtime! syntax/html.vim
+
+  if exists('b:current_syntax')
+    unlet b:current_syntax
+  endif
+endif
+
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+" don't use standard HiLink, it will not work with included syntax files
+if version < 508
+  command! -nargs=+ HtmlHiLink hi link <args>
+else
+  command! -nargs=+ HtmlHiLink hi def link <args>
+endif
+
+syn spell toplevel
+syn case ignore
+syn sync linebreaks=1
+
+let s:conceal = ''
+let s:concealends = ''
+if has('conceal') && get(g:, 'vim_markdown_conceal', 1)
+  let s:conceal = ' conceal'
+  let s:concealends = ' concealends'
+endif
+
+" additions to HTML groups
+if get(g:, 'vim_markdown_emphasis_multiline', 1)
+    let s:oneline = ''
+else
+    let s:oneline = ' oneline'
+endif
+execute 'syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend' . s:oneline
+execute 'syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend' . s:oneline
+execute 'syn region htmlBold start="\%(^\|\s\)\*\*\ze\S" end="\S\zs\*\*" keepend' . s:oneline
+execute 'syn region htmlBold start="\%(^\|\s\)\zs__\ze\S" end="\S\zs__" keepend' . s:oneline
+execute 'syn region htmlBoldItalic start="\%(^\|\s\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend' . s:oneline
+execute 'syn region htmlBoldItalic start="\%(^\|\s\)\zs___\ze\S" end="\S\zs___" keepend' . s:oneline
+
+" [link](URL) | [link][id] | [link][] | ![image](URL)
+syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"
+execute 'syn region mkdID matchgroup=mkdDelimiter    start="\["    end="\]" contained oneline' . s:conceal
+execute 'syn region mkdURL matchgroup=mkdDelimiter   start="("     end=")"  contained oneline' . s:conceal
+execute 'syn region mkdLink matchgroup=mkdDelimiter  start="\\\@<!!\?\[" end="\n\{-,1}[^]]\{-}\zs\]\ze[[(]" contains=@mkdNonListItem,@Spell nextgroup=mkdURL,mkdID skipwhite oneline' . s:concealends
+
+" Autolink without angle brackets.
+" mkd  inline links:      protocol     optional  user:pass@  sub/domain                    .com, .co.uk, etc         optional port   path/querystring/hash fragment
+"                         ------------ _____________________ ----------------------------- _________________________ ----------------- __
+syn match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
+
+" Autolink with parenthesis.
+syn region  mkdInlineURL matchgroup=mkdDelimiter start="(\(https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*)\)\@=" end=")"
+
+" Autolink with angle brackets.
+syn region mkdInlineURL matchgroup=mkdDelimiter start="\\\@<!<\ze[a-z][a-z0-9,.-]\{1,22}:\/\/[^> ]*>" end=">"
+
+" Link definitions: [id]: URL (Optional Title)
+syn region mkdLinkDef matchgroup=mkdDelimiter   start="^ \{,3}\zs\[" end="]:" oneline nextgroup=mkdLinkDefTarget skipwhite
+syn region mkdLinkDefTarget start="<\?\zs\S" excludenl end="\ze[>[:space:]\n]"   contained nextgroup=mkdLinkTitle,mkdLinkDef skipwhite skipnl oneline
+syn region mkdLinkTitle matchgroup=mkdDelimiter start=+"+     end=+"+  contained
+syn region mkdLinkTitle matchgroup=mkdDelimiter start=+'+     end=+'+  contained
+syn region mkdLinkTitle matchgroup=mkdDelimiter start=+(+     end=+)+  contained
+
+"HTML headings
+syn region htmlH1       start="^\s*#"                   end="$" contains=@Spell
+syn region htmlH2       start="^\s*##"                  end="$" contains=@Spell
+syn region htmlH3       start="^\s*###"                 end="$" contains=@Spell
+syn region htmlH4       start="^\s*####"                end="$" contains=@Spell
+syn region htmlH5       start="^\s*#####"               end="$" contains=@Spell
+syn region htmlH6       start="^\s*######"              end="$" contains=@Spell
+syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
+syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
+
+"define Markdown groups
+syn match  mkdLineBreak    /  \+$/
+syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLineBreak,@Spell
+syn region mkdCode         start=/\(\([^\\]\|^\)\\\)\@<!`/ end=/\(\([^\\]\|^\)\\\)\@<!`/
+syn region mkdCode         start=/\s*``[^`]*/              end=/[^`]*``\s*/
+syn region mkdCode         start=/^\s*\z(`\{3,}\)[^`]*$/   end=/^\s*\z1`*\s*$/
+syn region mkdCode         start=/\s*\~\~[^\~]*/           end=/[^\~]*\~\~\s*/
+syn region mkdCode         start=/^\s*\z(\~\{3,}\)\s*[0-9A-Za-z_+-]*\s*$/         end=/^\s*\z1\~*\s*$/
+syn region mkdCode         start="<pre[^>]*\\\@<!>"        end="</pre>"
+syn region mkdCode         start="<code[^>]*\\\@<!>"       end="</code>"
+syn region mkdFootnote     start="\[^"                     end="\]"
+syn match  mkdCode         /^\s*\n\(\(\s\{8,}[^ ]\|\t\t\+[^\t]\).*\n\)\+/
+syn match  mkdCode         /\%^\(\(\s\{4,}[^ ]\|\t\+[^\t]\).*\n\)\+/
+syn match  mkdCode         /^\s*\n\(\(\s\{4,}[^ ]\|\t\+[^\t]\).*\n\)\+/ contained
+syn match  mkdListItem     /^\s*\%([-*+]\|\d\+\.\)\s\+/ contained
+syn region mkdListItemLine start="^\s*\%([-*+]\|\d\+\.\)\s\+" end="$" oneline contains=@mkdNonListItem,mkdListItem,@Spell
+syn region mkdNonListItemBlock start="\(\%^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@!\|\n\(\_^\_$\|\s\{4,}[^ ]\|\t+[^\t]\)\@!\)" end="^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@=" contains=@mkdNonListItem,@Spell
+syn match  mkdRule         /^\s*\*\s\{0,1}\*\s\{0,1}\*$/
+syn match  mkdRule         /^\s*-\s\{0,1}-\s\{0,1}-$/
+syn match  mkdRule         /^\s*_\s\{0,1}_\s\{0,1}_$/
+syn match  mkdRule         /^\s*-\{3,}$/
+syn match  mkdRule         /^\s*\*\{3,5}$/
+
+" YAML frontmatter
+if get(g:, 'vim_markdown_frontmatter', 0)
+  syn include @yamlTop syntax/yaml.vim
+  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop keepend
+  unlet! b:current_syntax
+endif
+
+if get(g:, 'vim_markdown_toml_frontmatter', 0)
+  try
+    syn include @tomlTop syntax/toml.vim
+    syn region Comment matchgroup=mkdDelimiter start="\%^+++$" end="^+++$" transparent contains=@tomlTop keepend
+    unlet! b:current_syntax
+  catch /E484/
+    syn region Comment matchgroup=mkdDelimiter start="\%^+++$" end="^+++$"
+  endtry
+endif
+
+if get(g:, 'vim_markdown_json_frontmatter', 0)
+  try
+    syn include @jsonTop syntax/json.vim
+    syn region Comment matchgroup=mkdDelimiter start="\%^{$" end="^}$" contains=@jsonTop keepend
+    unlet! b:current_syntax
+  catch /E484/
+    syn region Comment matchgroup=mkdDelimiter start="\%^{$" end="^}$"
+  endtry
+endif
+
+if get(g:, 'vim_markdown_math', 0)
+  syn include @tex syntax/tex.vim
+  syn region mkdMath start="\\\@<!\$" end="\$" contains=@tex keepend
+  syn region mkdMath start="\\\@<!\$\$" end="\$\$" contains=@tex keepend
+endif
+
+syn include @rust syntax/rust.vim
+syn region mkdRust start="\`\`\`$" end="\`\`\`$" contains=@rust keepend
+syn region mkdRust start="\`\`\`rust" end="\`\`\`$" contains=@rust keepend
+syn region mkdRust start="\`\`\`no_run" end="\`\`\`$" contains=@rust keepend
+
+syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdRust
+
+"highlighting for Markdown groups
+HtmlHiLink mkdString        String
+HtmlHiLink mkdCode          String
+HtmlHiLink mkdCodeStart     String
+HtmlHiLink mkdCodeEnd       String
+HtmlHiLink mkdFootnote      Comment
+HtmlHiLink mkdBlockquote    Comment
+HtmlHiLink mkdListItem      Identifier
+HtmlHiLink mkdRule          Identifier
+HtmlHiLink mkdLineBreak     Visual
+HtmlHiLink mkdFootnotes     htmlLink
+HtmlHiLink mkdLink          htmlLink
+HtmlHiLink mkdURL           htmlString
+HtmlHiLink mkdInlineURL     htmlLink
+HtmlHiLink mkdID            Identifier
+HtmlHiLink mkdLinkDef       mkdID
+HtmlHiLink mkdLinkDefTarget mkdURL
+HtmlHiLink mkdLinkTitle     htmlString
+HtmlHiLink mkdDelimiter     Delimiter
+
+let b:current_syntax = "mkd"
+
+delcommand HtmlHiLink
+" vim: ts=2


### PR DESCRIPTION
`K` now opens a new split containing the documentation for the element
under the cursor.

Added vim syntax highlighting of documentation split.

In sync with [racer's pull request 540](https://github.com/phildawes/racer/pull/540).

![example](http://i.imgur.com/i4CEtuJ.gif)
