### PR TITLE
Fix name error introduced in previous commit

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -284,7 +284,7 @@ endfunction
 function! s:Init()
     setlocal omnifunc=RacerComplete
 
-    nnoremap <silent><buffer> <Plug>RacerGoToDefinitionSplit
+    nnoremap <silent><buffer> <Plug>RacerGoToDefinition
           \ :call <SID>RacerGoToDefinition()<CR>
     nnoremap <silent><buffer> <Plug>RacerGoToDefinitionSplit
           \ :vsplit<CR>:call <SID>RacerGoToDefinition()<CR>


### PR DESCRIPTION
Unfortunately the previous commit introduced a name error with
RacerGoToDefinition and RacerGoToDefinitionSplit, more specifically former
was mistakenly defined with the name of the latter.
