### PR TITLE
Fix E37 error in the case of unsaved buffer on going to definition

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -233,7 +233,11 @@ function! s:RacerJumpToLocation(filename, linenum, colnum)
         " Record jump mark
         normal! m`
         if a:filename != bufname('%')
-            exec 'keepjumps e ' . fnameescape(a:filename)
+            try
+                exec 'keepjumps e ' . fnameescape(a:filename)
+            catch /^Vim\%((\a\+)\)\=:E37/
+                " When the buffer is not saved, E37 is thrown.  We can ignore it.
+            endtry
         endif
         call cursor(a:linenum, a:colnum+1)
         " Center definition on screen


### PR DESCRIPTION
I found an E37 error occurred when I'd go to the definition of variable on unsaved buffer.

```
Error detected while processing function <SNR>95_RacerGoToDefinition[20]..<SNR>95_RacerJumpToLocation:
line    5:
E37: No write since last change (add ! to override)
```

repro:
1. `$ echo "fn main() {\n  let foo = 42;\n  foo;\n}" > tmp.rs`
2. Open the file with Vim
3. `:set modified`
4. Move cursor to `foo` in line3
5. Enter `gd`

I fixed this by catching the error.
