### PR TITLE
Fix highlight group name: NONE -> None

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -266,7 +266,7 @@ function! RacerComplete(findstart, base)
 endfunction
 
 function! s:Warn(msg)
-    echohl WarningMsg | echomsg a:msg | echohl NONE
+    echohl WarningMsg | echomsg a:msg | echohl None
 endfunction
 
 function! s:ErrorCheck()


### PR DESCRIPTION
Highlight group name is wrong hence `:echomsg` continues to highlight messages after warning.
