### PR TITLE
Key mappings should be disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ This plugin allows vim to use [Racer](http://github.com/phildawes/racer) for Rus
   let g:racer_experimental_completer = 1
   ```
 
-## Mappings
+## Example Mappings
 
-* In insert mode use `C-x-C-o` to search for completions
+vim-racer enables `C-x-C-o` to search for completions and provides several `<Plug>` mappings for source code navigation. These mappings are not enabled by default. 
 
-* In normal mode type `gd` to go to a definition
-
-* In normal mode type `gs` to splitted open a definition
-
-* In normal mode type `gx` to vsplitted open a definition
+```
+au FileType rust nmap <leader>gd <Plug>(rust-def)
+au FileType rust nmap <leader>gs <Plug>(rust-def-split)
+au FileType rust nmap <leader>gx <Plug>(rust-def-split-vertical)
+au FileType rust nmap <leader>d  <Plug>(rust-doc)
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin allows vim to use [Racer](http://github.com/phildawes/racer) for Rus
 
   ```
   set hidden
-  let g:racer_cmd = "<path-to-racer>/target/release/racer"
+  let g:racer_cmd = "/path/to/racer/bin"
   ```
 
 4. If you want completions to show the complete function definition (e.g. its arguments and return type), enable the experimental completer:
@@ -43,11 +43,18 @@ This plugin allows vim to use [Racer](http://github.com/phildawes/racer) for Rus
 
 ## Example Mappings
 
-vim-racer enables `C-x-C-o` to search for completions and provides several `<Plug>` mappings for source code navigation. These mappings are not enabled by default. 
+vim-racer enables `C-x-C-o` to search for completions and provides several
+`<Plug>` mappings for source code navigation. These mappings are not enabled by
+default but you can easily use them by adding the following lines to your
+`.vimrc` (Or `init.vim` in case of Neovim). 
+
+For example, with the following mappings you can navigate to the identifier under
+the cursor and open it on the current buffer, on an horizontal or vertical split,
+or go straight to the documentation:
 
 ```
-au FileType rust nmap <leader>gd <Plug>(rust-def)
-au FileType rust nmap <leader>gs <Plug>(rust-def-split)
-au FileType rust nmap <leader>gx <Plug>(rust-def-split-vertical)
-au FileType rust nmap <leader>d  <Plug>(rust-doc)
+au FileType rust nmap gd <Plug>(rust-def)
+au FileType rust nmap gs <Plug>(rust-def-split)
+au FileType rust nmap gx <Plug>(rust-def-vertical)
+au FileType rust nmap <leader>gd <Plug>(rust-doc)
 ```

--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -270,20 +270,14 @@ endfunction
 function! s:Init()
     setlocal omnifunc=RacerComplete
 
-    nnoremap <silent><buffer> <Plug>RacerGoToDefinitionDrect
+    nnoremap <silent><buffer> <Plug>(rust-def)
           \ :call <SID>RacerGoToDefinition()<CR>
-    nnoremap <silent><buffer> <Plug>RacerGoToDefinitionSplit
+    nnoremap <silent><buffer> <Plug>(rust-def-split)
           \ :split<CR>:call <SID>RacerGoToDefinition()<CR>
-    nnoremap <silent><buffer> <Plug>RacerGoToDefinitionVSplit
+    nnoremap <silent><buffer> <Plug>(rust-def-split-vertical)
           \ :vsplit<CR>:call <SID>RacerGoToDefinition()<CR>
-    nnoremap <silent><buffer> <Plug>RacerShowDocumentation
+    nnoremap <silent><buffer> <Plug>(rust-doc)
           \ :call <SID>RacerShowDocumentation()<CR>
-    if !exists('g:racer_no_default_keymappings')
-      nmap <buffer> gd <Plug>RacerGoToDefinitionDrect
-      nmap <buffer> gs <Plug>RacerGoToDefinitionSplit
-      nmap <buffer> gx <Plug>RacerGoToDefinitionVSplit
-      nmap <buffer> K  <Plug>RacerShowDocumentation
-    endif
 endfunction
 
 augroup vim-racer

--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -274,7 +274,7 @@ function! s:Init()
           \ :call <SID>RacerGoToDefinition()<CR>
     nnoremap <silent><buffer> <Plug>(rust-def-split)
           \ :split<CR>:call <SID>RacerGoToDefinition()<CR>
-    nnoremap <silent><buffer> <Plug>(rust-def-split-vertical)
+    nnoremap <silent><buffer> <Plug>(rust-def-vertical)
           \ :vsplit<CR>:call <SID>RacerGoToDefinition()<CR>
     nnoremap <silent><buffer> <Plug>(rust-doc)
           \ :call <SID>RacerShowDocumentation()<CR>


### PR DESCRIPTION
The default mappings provided by `vim-racer` can conflict with existing ones. For this reason I believe that the most sensible is to disable them by default and expose the `<Plug>` mappings on the `README`.

In addition to this, the README has also been updated for a less confusing configuration of the `let g:racer_cmd` parameter.