### PR TITLE
Fix variable assignment typo

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -22,7 +22,7 @@ let s:is_win = has('win32') || has('win64')
 
 if !exists('g:racer_cmd')
     let s:sep = s:is_win ? '\' : '/'
-    le s:path = join([
+    let s:path = join([
             \ escape(expand('<sfile>:p:h'), '\'),
             \ '..',
             \ 'target',


### PR DESCRIPTION
Updated `racer-rust` and got the following error message:

```
Error detected while processing /Users/azure/.dotfiles/vim/plugged/vim-racer/plugin/racer.vim:
line   31:
E121: Undefined variable: s:path
E116: Invalid arguments for function isdirectory(s:path)
E15: Invalid expression: isdirectory(s:path)
line   39:
E121: Undefined variable: g:racer_cmd
E116: Invalid arguments for function expand(g:racer_cmd)
E15: Invalid expression: expand(g:racer_cmd)
Press ENTER or type command to continue
```

Fix is correcting a typo introduced in [333fdf9](https://github.com/racer-rust/vim-racer/commit/333fdf9cfd5e2355372310222e364438d9d2510f#diff-53b8e24e88a2a4033e83f9faa575b393R25).