### PR TITLE
Improve racer#ShowDocumentation()

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -82,6 +82,11 @@ function! s:RacerSplitLine(line)
         \   ),
         \   '\\n', '\n', 'g'
         \ )
+
+    " Add empty lines to before/after code snippets and before section titles
+    let docs =  substitute(docs, '\n```\zs\n', '\n\n', 'g')
+    let docs =  substitute(docs, '\n\ze\%(```rust\|#\+ .\+\)\n', '\n\n', 'g')
+
     let parts = add(parts[:6], docs)
     let parts = map(copy(parts), 'substitute(v:val, ''{PLACEHOLDER}'', '';'', ''g'')')
 

--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -40,23 +40,19 @@ function! s:RacerGetExpCompletions(base)
 
         if kind ==# 'f'
             " function
-            let completion['menu'] = substitute(
-                \   substitute(
-                \     substitute(info, '\(pub\|fn\) ', '', 'g'),
-                \     '{*$', '', ''
-                \   ),
-                \   ' where\s\?.*$', '', ''
-                \ )
+            let menu = substitute(info, '\(pub\|fn\) ', '', 'g')
+            let menu = substitute(menu, '{*$', '', '')
+            let menu = substitute(menu, ' where\s\?.*$', '', '')
+            let completion['menu'] = menu
             if g:racer_insert_paren == 1
                 let completion['abbr'] = completions[0]
                 let completion['word'] .= '('
             endif
             let completion['info'] = info
         elseif kind ==# 's' " struct
-            let completion['menu'] = substitute(
-                \   substitute(info, '\(pub\|struct\) ', '', 'g'),
-                \   '{*$', '', ''
-                \ )
+            let menu = substitute(info, '\(pub\|struct\) ', '', 'g')
+            let menu = substitute(menu, '{*$', '', '')
+            let completion['menu'] = menu
         endif
 
         if stridx(tolower(completions[0]), tolower(a:base)) == 0
@@ -72,16 +68,11 @@ function! s:RacerSplitLine(line)
     let placeholder = '{PLACEHOLDER}'
     let line = substitute(a:line, '\\;', placeholder, 'g')
     let parts = split(line, separator)
-    let docs = substitute(
-        \   substitute(
-        \     substitute(
-        \       substitute(get(parts, 7, ''), '^\"\(.*\)\"$', '\1', ''),
-        \       '\\\"', '\"', 'g'
-        \     ),
-        \     '\\''', '''', 'g'
-        \   ),
-        \   '\\n', '\n', 'g'
-        \ )
+
+    let docs = substitute(get(parts, 7, ''), '^\"\(.*\)\"$', '\1', '')
+    let docs = substitute(docs, '\\\"', '\"', 'g')
+    let docs = substitute(docs, '\\''', '''', 'g')
+    let docs = substitute(docs, '\\n', '\n', 'g')
 
     " Add empty lines to before/after code snippets and before section titles
     let docs =  substitute(docs, '\n```\zs\n', '\n\n', 'g')


### PR DESCRIPTION
I added empty lines to before/after code snippets and before section title. It makes output more readable as following.

### Before this PR

<img width="540" alt="2017-07-16 23 50 09" src="https://user-images.githubusercontent.com/823277/28248573-a086836c-6a81-11e7-947a-30fdacac0dfe.png">

### After this PR

<img width="538" alt="2017-07-16 23 49 12" src="https://user-images.githubusercontent.com/823277/28248568-90db424a-6a81-11e7-959c-f37f2a19d991.png">

And I added small refactorings. Nested `substitute()` is so unreadable...