### PR TITLE
fix GoToDefinition on cygwin and mingw

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -216,6 +216,11 @@ function! racer#GoToDefinition()
             let linenum = split(line[6:], ',')[1]
             let colnum = split(line[6:], ',')[2]
             let fname = split(line[6:], ',')[3]
+            " if on cygwin or mingw, use cygpath to fix the filepath
+            if executable("cygpath")
+                let fname = system("cygpath " . shellescape(fname))[:-1]
+                let fname = fname[:strlen(fname)-2]
+            endif
             call s:RacerJumpToLocation(fname, linenum, colnum)
             break
         endif


### PR DESCRIPTION
This small patch fixes `GoToDefinition` on cygwin and mingw. Without this patch, `GoToDefinition` is broken because the racer binary can spit out a mix of forward and backwards slashes in the file path, and vim's `fnameescape` doesn't handle the backwards slashes in the way we need them to be handled.

This solution uses the presence of the `cygpath` executable to determine if we are on cygwin or mingw, and then calls `cygpath` to normalize the path to a unix-style path (all forward slashes) if we are.

An alternative implementation would have the new code in the `RacerJumpToLocation` function. However, I think it makes more sense to handle the path conversion closer to the `racer` call.

Note that the `[:-1]` is used to drop the terminating null character that the system call to `cygpath` returns. There might be a more robust way to handle this, such as a string substitution, but this seems to work well enough.