### PR TITLE
Mimic Racer's automatic discovery of source path

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -286,7 +286,21 @@ function! s:ErrorCheck()
         return 1
     endif
     if !exists('$RUST_SRC_PATH')
-        call s:Warn('No $RUST_SRC_PATH variable found.')
+        if executable('rustc')
+            let sep = s:is_win ? '\' : '/'
+            let path = join([
+                \ substitute(system('rustc --print sysroot'), '\n$', '', ''),
+                \ 'lib',
+                \ 'rustlib',
+                \ 'src',
+                \ 'rust',
+                \ 'src',
+                \ ], sep)
+            if isdirectory(path)
+                return 0
+            endif
+        endif
+        call s:Warn('Could not locate Rust source. Try setting $RUST_SRC_PATH.')
         return 1
     endif
 endfunction


### PR DESCRIPTION
Adds a fallback check for the Rust source path if `$RUST_SRC_PATH` is not set, based on this: https://github.com/racer-rust/racer/pull/598

This should avoid recreating #90.

It should be compatible across Windows, Mac, and Linux, but I have only tested it on a Mac.