### PR TITLE
account for completion in first column of buffer

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -30,7 +30,7 @@ function! s:RacerGetPrefixCol(base)
     let prefixline = split(res, '\n')[0]
     let startbyte = split(prefixline[7:], ',')[0]
     call delete(b:tmpfname)
-    return startbyte - line2byte(byte2line(startbyte)) + 1
+    return startbyte - line2byte(byte2line(startbyte)) + (col == 1 ? 0 : 1)
 endfunction
 
 function! s:RacerGetExpCompletions(base)


### PR DESCRIPTION
Completion start is one column off if you are in the first column of a buffer:

```
b<C-x><C-o> -> bbool
 b<C-x><C-o> -> bool
```