### PR TITLE
Simplify Windows check

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -1,4 +1,4 @@
-let s:is_win = has('win32') || has('win64')
+let s:is_win = has('win32')
 
 function! racer#GetRacerCmd() abort
   if !exists('g:racer_cmd')


### PR DESCRIPTION
Since `has('win32')` covers `has('win64')`, `has('win32')` is enough.