### PR TITLE
Whitespace tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ This plugin allows vim to use [Racer](http://github.com/phildawes/racer) for Rus
   ```
   NeoBundle 'racer-rust/vim-racer'
   ```
-  
+
   vim-plug users:
   ```
   Plug 'racer-rust/vim-racer'
   ```
-  
+
   Pathogen users:
   ```
   git clone --depth=1 https://github.com/racer-rust/vim-racer.git ~/.vim/bundle/vim-racer

--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -1,22 +1,22 @@
 let s:is_win = has('win32')
 
 function! racer#GetRacerCmd() abort
-  if !exists('g:racer_cmd')
-    let sep = s:is_win ? '\' : '/'
-    let path = join([
-          \ escape(expand('<sfile>:p:h'), '\'),
-          \ '..',
-          \ 'target',
-          \ 'release',
-          \ ], sep)
-    if isdirectory(path)
-      let pathsep = s:is_win ? ';' : ':'
-      let $PATH .= pathsep . path
+    if !exists('g:racer_cmd')
+        let sep = s:is_win ? '\' : '/'
+        let path = join([
+              \ escape(expand('<sfile>:p:h'), '\'),
+              \ '..',
+              \ 'target',
+              \ 'release',
+              \ ], sep)
+        if isdirectory(path)
+            let pathsep = s:is_win ? ';' : ':'
+            let $PATH .= pathsep . path
+        endif
+        let g:racer_cmd = 'racer'
     endif
-    let g:racer_cmd = 'racer'
-  endif
 
-  return expand(g:racer_cmd)
+    return expand(g:racer_cmd)
 endfunction
 
 function! s:RacerGetPrefixCol(base)


### PR DESCRIPTION
- Remove trailing whitespace in the README
- Consistently use four space indentation in racer#GetRacerCmd()