### PR TITLE
update default rust-src-path

### DIFF
--- a/autoload/racer.vim
+++ b/autoload/racer.vim
@@ -314,7 +314,7 @@ function! s:ErrorCheck()
                 \ 'rustlib',
                 \ 'src',
                 \ 'rust',
-                \ 'src',
+                \ 'library',
                 \ ], sep)
             if isdirectory(path)
                 return 0


### PR DESCRIPTION
Newer rust version install rust-src to `$(rustc --print sysroot)/lib/rustlib/src/rust/library` instead of `$(rustc --print sysroot)/lib/rustlib/src/rust/src`